### PR TITLE
Enhance API by avoiding macros

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -3,13 +3,13 @@ name: CI
 on: [ push, pull_request ]
 
 jobs:
-  build:
+  linux:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal
+    container: crystallang/crystal:latest-alpine
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: shards install
-    - name: Run tests
-      run: crystal spec
+      - name: Download source code
+        uses: actions/checkout@v3
+      - name: Format
+        run: "crystal tool format --check"
+      - name: Run tests
+        run: "crystal spec --warnings all --error-on-warnings"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Postmodern
+Copyright (c) 2020-2023 Postmodern
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,25 +8,20 @@ libc's [ioctl] for [Crystal][crystal].
 
 ## Features
 
-### Functions
-
 * Maps in the libc `ioctl` function.
-* Provides C equivalent macros for defining and working with ioctl numbers:
+* Provides C equivalent methods for defining and working with ioctl numbers:
 
-  | C           | Crystal                       |
-  |-------------|-------------------------------|
-  | `_IOC`      | `ioctl_ioc(dir,type,nr,size)` |
-  | `_IO`       | `ioctl_io(type,nr)`           |
-  | `_IOR`      | `ioctl_ior(type,nr,size)`     |
-  | `_IOW`      | `ioctl_iow(type,nr,size)`     |
-  | `_IOWR`     | `ioctl_iowr(type,nr,size)`    |
-  | `_IOR_BAD`  | `ioctl_ior_bad(type,nr,size)` |
-  | `_IOW_BAD`  | `ioctl_iow_bad(type,nr,size)` |
-  | `_IOWR_BAD` | `ioctl_iowr_bad(type,nr,size)`|
-  | `_IOC_DIR`  | `ioctl_dir(nr)`               |
-  | `_IOC_TYPE` | `ioctl_type(nr)`              |
-  | `_IOC_NR`   | `ioctl_nr(nr)`                |
-  | `_IOC_SIZE` | `ioctl_size(nr)`              |
+  | C           | Crystal                         |
+  |-------------|---------------------------------|
+  | `_IOC`      | `IOCTL::_IOC(dir,type,nr,size)` |
+  | `_IO`       | `IOCTL::_IOC(type,nr)`          |
+  | `_IOR`      | `IOCTL::_IOR(type,nr,size)`     |
+  | `_IOW`      | `IOCTL::_IOW(type,nr,size)`     |
+  | `_IOWR`     | `IOCTL::_IOWR(type,nr,size)`    |
+  | `_IOC_DIR`  | `IOCTL::_IOC_DIR(dir)`          |
+  | `_IOC_TYPE` | `IOCTL::_IOC_TYPE(type)`        |
+  | `_IOC_NR`   | `IOCTL::_IOC_NR(nr)`            |
+  | `_IOC_SIZE` | `IOCTL::_IOC_SIZE(size)`        |
 
 ## Installation
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: ioctl
-version: 0.1.2
+version: 1.0.0
 
 description: |
   crystal bindings for libc's ioctl(2)
@@ -10,8 +10,3 @@ authors:
 crystal: ">= 0.33.0"
 
 license: MIT
-
-development_dependencies:
-  spectator:
-    gitlab: arctic-fox/spectator
-    version: "~> 0.9, >= 0.9.9"

--- a/spec/ioctl_spec.cr
+++ b/spec/ioctl_spec.cr
@@ -1,6 +1,7 @@
-require "./spec_helper"
+require "../src/ioctl"
+require "spec"
 
-Spectator.describe IOCTL do
+describe IOCTL do
   describe ".ioctl" do
     context "when given a valid ioctl request number" do
       it "must populate the given pointer" do
@@ -8,17 +9,45 @@ Spectator.describe IOCTL do
 
         IOCTL.ioctl(STDOUT.fd, IOCTLS::TIOCGWINSZ, pointerof(winsize))
 
-        expect(winsize.ws_row).to be > 0
-        expect(winsize.ws_col).to be > 0
+        (winsize.ws_row > 0).should be_true
+        (winsize.ws_col > 0).should be_true
       end
     end
 
     context "when given an invalid ioctl request number" do
-      it do
-        expect {
-          subject.ioctl(1, 0xffffffff_u32, nil)
-        }.to raise_error(IOCTL::Error)
+      it "raises" do
+        expect_raises(IOCTL::Error) do
+          IOCTL.ioctl(1, 0xffffffff_u32, nil)
+        end
       end
+
+      it "returns an Errno" do
+        IOCTL.ioctl?(1, 0xffffffff_u32, nil).should eq Errno::ENOTTY
+      end
+    end
+  end
+
+  describe "._IO" do
+    it "calculates the correct value for UI_DEV_CREATE" do
+      IOCTL._IO('U', 1).should eq 21761_u32
+    end
+  end
+
+  describe "._IOW" do
+    it "calculates the correct value for UI_SET_EVBIT" do
+      IOCTL._IOW('U', 100, UInt32).should eq 1074025828_u32
+    end
+  end
+
+  describe "._IOR" do
+    it "calculates the correct value for USBTMC_IOCTL_API_VERSION" do
+      IOCTL._IOR(91, 16, UInt32).should eq 2147769104_u32
+    end
+  end
+
+  describe "._IOWR" do
+    it "calculates the correct value for USBTMC_IOCTL_WRITE_RESULT" do
+      IOCTL._IOWR(91, 15, UInt32).should eq 3221510927_u32
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,0 @@
-require "../src/ioctl"
-require "spectator"

--- a/src/asm-generic/ioctl.cr
+++ b/src/asm-generic/ioctl.cr
@@ -1,7 +1,7 @@
 module IOCTL
   # ioctl command encoding: 32 bits total, command in lower 16 bits,
   # size of the parameter structure in the lower 14 bits of the
-  # upper 16 bits.                                                                       
+  # upper 16 bits.
   # Encoding the size of the parameter structure in the ioctl request
   # is useful for catching programs compiled with old versions
   # and to avoid overwriting user space outside the user buffer area.
@@ -14,18 +14,18 @@ module IOCTL
   # bits are indeed used as a type field, so we might just as well make
   # this explicit here.  Please be sure to use the decoding macros
   # below from now on.
-  IOC_NRBITS = 8
+  IOC_NRBITS   = 8
   IOC_TYPEBITS = 8
 
   # Let any architecture override either of the following before
   # including this file.
   IOC_SIZEBITS = 14
-  DIRBITS  = 2
+  DIRBITS      =  2
 
-  IOC_NRMASK   = ((1 << IOC_NRBITS)-1)
-  IOC_TYPEMASK = ((1 << IOC_TYPEBITS)-1)
-  IOC_SIZEMASK = ((1 << IOC_SIZEBITS)-1)
-  IOC_DIRMASK  = ((1 << IOC_DIRBITS)-1)
+  IOC_NRMASK   = (1 << IOC_NRBITS) - 1
+  IOC_TYPEMASK = (1 << IOC_TYPEBITS) - 1
+  IOC_SIZEMASK = (1 << IOC_SIZEBITS) - 1
+  IOC_DIRMASK  = (1 << IOC_DIRBITS) - 1
 
   IOC_NRSHIFT   = 0
   IOC_TYPESHIFT = IOC_NRSHIFT + IOC_NRBITS
@@ -34,85 +34,63 @@ module IOCTL
 
   # Direction bits, which any architecture can choose to override
   # before including this file.
-  #
-  # NOTE: _IOC_WRITE means userland is writing and kernel is
-  # reading. _IOC_READ means userland is reading and kernel is writing.
-
-  IOC_NONE  = 0_u32
-  IOC_WRITE = 1_u32
-  IOC_READ  = 2_u32
+  enum IOC : UInt32
+    NONE
+    # _IOC::WRITE means userland is writing and kernel is reading.
+    WRITE
+    # IOC::READ means userland is reading and kernel is writing.
+    READ
+  end
 
   # for the drivers/sound files...
-  IOC_IN        = (IOC_WRITE << IOC_DIRSHIFT)
-  IOC_OUT       = (IOC_READ << IOC_DIRSHIFT)
-  IOC_INOUT     = ((IOC_WRITE | IOC_READ) << IOC_DIRSHIFT)
-  IOCSIZE_MASK  = (IOC_SIZEMASK << IOC_SIZESHIFT)
-  IOCSIZE_SHIFT = (IOC_SIZESHIFT)
-end
+  IOC_IN        = IOC_WRITE << IOC_DIRSHIF
+  IOC_OUT       = IOC_READ << IOC_DIRSHIFT
+  IOC_INOUT     = (IOC_WRITE | IOC_READ) << IOC_DIRSHIFT
+  IOCSIZE_MASK  = IOC_SIZEMASK << IOC_SIZESHIFT
+  IOCSIZE_SHIFT = IOC_SIZESHIFT
 
-macro ioctl_ioc(dir,type,nr,size)
-  {% begin %}
-	((({{ dir }})  << IOCTL::IOC_DIRSHIFT) | \
-   {% if type.is_a?(CharLiteral) %}
-   (({{ type }}.ord) << IOCTL::IOC_TYPESHIFT) | \
-   {% else %}
-	 (({{ type }}) << IOCTL::IOC_TYPESHIFT) | \
-   {% end %}
-	 (({{ nr }})   << IOCTL::IOC_NRSHIFT) | \
-	 (({{ size }}) << IOCTL::IOC_SIZESHIFT))
-  {% end %}
-end
+  # Used to create numbers.
+  def _IOC(dir : IOC, type : Int | Char, nr : Int, size : Int) : UInt32
+    (dir.value << IOC_DIRSHIFT) | \
+      ((type.is_a?(Char) ? type.ord : type) << IOC_TYPESHIFT) | \
+        (nr << IOC_NRSHIFT) | (size << IOC_SIZESHIFT)
+  end
 
-macro ioctl_ioc_typecheck(t)
-  sizeof({{ t }})
-end
+  def _IO(type : Char | Int, nr : Int) : UInt32
+    _IOC IOC::NONE, type, nr, 0
+  end
 
-# Used to create numbers.
-#
-# NOTE: _IOW means userland is writing and kernel is reading. _IOR
-# means userland is reading and kernel is writing.
+  # _IOR means userland is reading and kernel is writing.
+  def _IOR(type : Char | Int, nr : Int, size : T.class) : UInt32 forall T
+    _IOC IOC::READ, type, nr, sizeof(T)
+  end
 
-macro ioctl_io(type,nr)
-  ioctl_ioc(IOCTL::IOC_NONE,{{ type }},{{ nr }},0)
-end
+  # _IOW means userland is writing and kernel is reading.
+  def _IOW(type : Char | Int, nr : Int, size : T.class) : UInt32 forall T
+    _IOC IOC::WRITE, type, nr, sizeof(T)
+  end
 
-macro ioctl_ior(type,nr,size)
-  ioctl_ioc(IOCTL::IOC_READ,{{ type }},{{ nr }},ioctl_ioc_typecheck({{ size }}))
-end
+  def _IOWR(type : Char | Int, nr : Int, size : T.class) : UInt32 forall T
+    _IOC IOC::READ | IOC::WRITE, type, nr, sizeof(T)
+  end
 
-macro ioctl_iow(type,nr,size)
-  ioctl_ioc(IOCTL::IOC_WRITE,{{ type }},{{ nr }},ioctl_ioc_typecheck({{ size }}))
-end
+  # Decodes ioctl `dir` number.
+  def _IOC_DIR(dir : IOC)
+    (dir.value >> IOC_DIRSHIFT) & IOC_DIRMASK
+  end
 
-macro ioctl_iowr(type,nr,size)
-  ioctl_ioc(IOCTL::IOC_READ | IOCTL::IOC_WRITE,{{ type }},{{ nr }},ioctl_ioc_typecheck({{ size }}))
-end
+  # Decodes ioctl `type` number.
+  def _IOC_TYPE(type : Char | Int)
+    ((type.is_a?(Char) ? type.ord : type) >> IOC_TYPESHIFT) & IOC_TYPEMASK
+  end
 
-macro ioctl_ior_bad(type,nr,size)
-  ioctl_ioc(IOCTL::IOC_READ,{{ type }},{{ nr }},sizeof({{ size }}))
-end
+  # Decodes ioctl `nr` number.
+  def _IOC_NR(nr : Int)
+    (nr >> IOC_NRSHIFT) & IOC_NRMASK
+  end
 
-macro ioctl_iow_bad(type,nr,size)
-  ioctl_ioc(IOCTL::IOC_WRITE,{{ type }},{{ nr }},sizeof({{ size }}))
-end
-
-macro ioctl_iowr_bad(type,nr,size)
-  ioctl_ioc(IOCTL::IOC_READ | IOCTL::IOC_WRITE,{{ type }},{{ nr }},sizeof({{ size }}))
-end
-
-# used to decode ioctl numbers..
-macro ioctl_dir(nr)
-  ((({{ nr }}) >> IOCTL::IOC_DIRSHIFT) & IOCTL::IOC_DIRMASK)
-end
-
-macro ioctl_type(nr)
-  ((({{ nr }}) >> IOCTL::IOC_TYPESHIFT) & IOCTL::IOC_TYPEMASK)
-end
-
-macro ioctl_nr(nr)
-  ((({{ nr }}) >> IOCTL::IOC_NRSHIFT) & IOCTL::IOC_NRMASK)
-end
-
-macro ioctl_size(nr)
-  ((({{ nr }}) >> IOCTL::IOC_SIZESHIFT) & IOCTL::IOC_SIZEMASK)
+  # Decodes ioctl `size` number.
+  def _IOC_SIZE(size : Int)
+    (size >> IOC_SIZESHIFT) & IOC_SIZEMASK
+  end
 end

--- a/src/asm-generic/ioctls.cr
+++ b/src/asm-generic/ioctls.cr
@@ -13,50 +13,50 @@ module IOCTLS
   # 0x54 is just a magic number to make these relatively unique ('T')
 
   alias UInt = LibC::UInt
-  alias Int  = LibC::Int
+  alias Int = LibC::Int
   alias Termios2 = LibC::Termios
 
-  TCGETS		   = 0x5401_u32
-  TCSETS		   = 0x5402_u32
-  TCSETSW		   = 0x5403_u32
-  TCSETSF		   = 0x5404_u32
-  TCGETA		   = 0x5405_u32
-  TCSETA		   = 0x5406_u32
-  TCSETAW		   = 0x5407_u32
-  TCSETAF		   = 0x5408_u32
-  TCSBRK		   = 0x5409_u32
-  TCXONC		   = 0x540A_u32
-  TCFLSH		   = 0x540B_u32
-  TIOCEXCL	   = 0x540C_u32
-  TIOCNXCL	   = 0x540D_u32
-  TIOCSCTTY	   = 0x540E_u32
-  TIOCGPGRP	   = 0x540F_u32
-  TIOCSPGRP	   = 0x5410_u32
-  TIOCOUTQ	   = 0x5411_u32
-  TIOCSTI		   = 0x5412_u32
+  TCGETS       = 0x5401_u32
+  TCSETS       = 0x5402_u32
+  TCSETSW      = 0x5403_u32
+  TCSETSF      = 0x5404_u32
+  TCGETA       = 0x5405_u32
+  TCSETA       = 0x5406_u32
+  TCSETAW      = 0x5407_u32
+  TCSETAF      = 0x5408_u32
+  TCSBRK       = 0x5409_u32
+  TCXONC       = 0x540A_u32
+  TCFLSH       = 0x540B_u32
+  TIOCEXCL     = 0x540C_u32
+  TIOCNXCL     = 0x540D_u32
+  TIOCSCTTY    = 0x540E_u32
+  TIOCGPGRP    = 0x540F_u32
+  TIOCSPGRP    = 0x5410_u32
+  TIOCOUTQ     = 0x5411_u32
+  TIOCSTI      = 0x5412_u32
   TIOCGWINSZ   = 0x5413_u32
   TIOCSWINSZ   = 0x5414_u32
-  TIOCMGET	   = 0x5415_u32
-  TIOCMBIS	   = 0x5416_u32
-  TIOCMBIC	   = 0x5417_u32
+  TIOCMGET     = 0x5415_u32
+  TIOCMBIS     = 0x5416_u32
+  TIOCMBIC     = 0x5417_u32
   TIOCMSET     = 0x5418_u32
   TIOCGSOFTCAR = 0x5419_u32
   TIOCSSOFTCAR = 0x541A_u32
-  FIONREAD	   = 0x541B_u32
-  TIOCINQ		   = FIONREAD
-  TIOCLINUX	   = 0x541C_u32
-  TIOCCONS	   = 0x541D_u32
-  TIOCGSERIAL	 = 0x541E_u32
-  TIOCSSERIAL	 = 0x541F_u32
-  TIOCPKT		   = 0x5420_u32
-  FIONBIO		   = 0x5421_u32
-  TIOCNOTTY	   = 0x5422_u32
-  TIOCSETD	   = 0x5423_u32
-  TIOCGETD	   = 0x5424_u32
-  TCSBRKP		   = 0x5425_u32 # Needed for POSIX tcsendbreak()
-  TIOCSBRK	   = 0x5427_u32 # BSD compatibility
-  TIOCCBRK	   = 0x5428_u32 # BSD compatibility
-  TIOCGSID	   = 0x5429_u32 # Return the session ID of FD
+  FIONREAD     = 0x541B_u32
+  TIOCINQ      = FIONREAD
+  TIOCLINUX    = 0x541C_u32
+  TIOCCONS     = 0x541D_u32
+  TIOCGSERIAL  = 0x541E_u32
+  TIOCSSERIAL  = 0x541F_u32
+  TIOCPKT      = 0x5420_u32
+  FIONBIO      = 0x5421_u32
+  TIOCNOTTY    = 0x5422_u32
+  TIOCSETD     = 0x5423_u32
+  TIOCGETD     = 0x5424_u32
+  TCSBRKP      = 0x5425_u32 # Needed for POSIX tcsendbreak()
+  TIOCSBRK     = 0x5427_u32 # BSD compatibility
+  TIOCCBRK     = 0x5428_u32 # BSD compatibility
+  TIOCGSID     = 0x5429_u32 # Return the session ID of FD
   TCGETS2      = ioctl_ior('T', 0x2A, Termios2)
   TCSETS2      = ioctl_iow('T', 0x2B, Termios2)
   TCSETSW2     = ioctl_iow('T', 0x2C, Termios2)
@@ -66,46 +66,46 @@ module IOCTLS
   TIOCGPTN     = ioctl_ior('T', 0x30, UInt) # Get Pty Number (of pty-mux device)
   TIOCSPTLCK   = ioctl_iow('T', 0x31, Int)  # Lock/unlock Pty
   TIOCGDEV     = ioctl_ior('T', 0x32, UInt) # Get primary device node of /dev/console
-  TCGETX       = 0x5432_u32 # SYS5 TCGETX compatibility
+  TCGETX       = 0x5432_u32                 # SYS5 TCGETX compatibility
   TCSETX       = 0x5433_u32
   TCSETXF      = 0x5434_u32
   TCSETXW      = 0x5435_u32
-  TIOCSIG      = ioctl_iow('T', 0x36, Int)  # pty: generate signal
-  TIOCVHANGUP	 = 0x5437_u32
+  TIOCSIG      = ioctl_iow('T', 0x36, Int) # pty: generate signal
+  TIOCVHANGUP  = 0x5437_u32
   TIOCGPKT     = ioctl_ior('T', 0x38, Int) # Get packet mode state
   TIOCGPTLCK   = ioctl_ior('T', 0x39, Int) # Get Pty lock state
   TIOCGEXCL    = ioctl_ior('T', 0x40, Int) # Get exclusive mode state
-  TIOCGPTPEER	 = ioctl_io('T', 0x41) # Safely open the slave
-  # TODO: 
+  TIOCGPTPEER  = ioctl_io('T', 0x41)       # Safely open the slave
+  # TODO:
   # TIOCGISO7816	ioctl_ior('T', 0x42, struct serial_iso7816)
   # TIOCSISO7816 = ioctl_iowr('T', 0x43, struct serial_iso7816)
 
   FIONCLEX        = 0x5450_u32
   FIOCLEX         = 0x5451_u32
-  FIOASYNC	      = 0x5452_u32
+  FIOASYNC        = 0x5452_u32
   TIOCSERCONFIG   = 0x5453_u32
   TIOCSERGWILD    = 0x5454_u32
-  TIOCSERSWILD	  = 0x5455_u32
-  TIOCGLCKTRMIOS	= 0x5456_u32
-  TIOCSLCKTRMIOS	= 0x5457_u32
-  TIOCSERGSTRUCT	= 0x5458_u32 # For debugging only
+  TIOCSERSWILD    = 0x5455_u32
+  TIOCGLCKTRMIOS  = 0x5456_u32
+  TIOCSLCKTRMIOS  = 0x5457_u32
+  TIOCSERGSTRUCT  = 0x5458_u32 # For debugging only
   TIOCSERGETLSR   = 0x5459_u32 # Get line status register
   TIOCSERGETMULTI = 0x545A_u32 # Get multiport config
   TIOCSERSETMULTI = 0x545B_u32 # Set multiport config
 
-  TIOCMIWAIT	= 0x545C_u32 # wait for a change on serial input line(s)
-  TIOCGICOUNT	= 0x545D_u32 # read serial port __inline__ interrupt counts
+  TIOCMIWAIT  = 0x545C_u32 # wait for a change on serial input line(s)
+  TIOCGICOUNT = 0x545D_u32 # read serial port __inline__ interrupt counts
 
   # Some arches already define FIOQSIZE due to a historical
   # conflict with a Hayes modem-specific ioctl value.
   FIOQSIZE = 0x5460_u32
 
   # Used for packet mode
-  TIOCPKT_DATA       = 0_u32
-  TIOCPKT_FLUSHREAD  = 1_u32
-  TIOCPKT_FLUSHWRITE = 2_u32
-  TIOCPKT_STOP       = 4_u32
-  TIOCPKT_START      = 8_u32
+  TIOCPKT_DATA       =  0_u32
+  TIOCPKT_FLUSHREAD  =  1_u32
+  TIOCPKT_FLUSHWRITE =  2_u32
+  TIOCPKT_STOP       =  4_u32
+  TIOCPKT_START      =  8_u32
   TIOCPKT_NOSTOP     = 16_u32
   TIOCPKT_DOSTOP     = 32_u32
   TIOCPKT_IOCTL      = 64_u32

--- a/src/bits/ioctl-types.cr
+++ b/src/bits/ioctl-types.cr
@@ -15,7 +15,7 @@ lib LibC
     c_oflag : UShort # output mode flags
     c_cflag : UShort # control mode flags
     c_lflag : UShort # local mode flags
-    c_line : UChar # line discipline
+    c_line : UChar   # line discipline
     c_cc : UChar[NCC]
   end
 
@@ -35,20 +35,20 @@ lib LibC
   # ioctl (fd, TIOCSERGETLSR, &result) where result may be as below
 
   # line disciplines
-  N_TTY          = 0
-  N_SLIP         = 1
-  N_MOUSE        = 2
-  N_PPP          = 3
-  N_STRIP        = 4
-  N_AX25         = 5
-  N_X25          = 6	# X.25 async
-  N_6PACK        = 7
-  N_MASC         = 8	# Mobitex module
-  N_R3964        = 9	# Simatic R3964 module
+  N_TTY          =  0
+  N_SLIP         =  1
+  N_MOUSE        =  2
+  N_PPP          =  3
+  N_STRIP        =  4
+  N_AX25         =  5
+  N_X25          =  6 # X.25 async
+  N_6PACK        =  7
+  N_MASC         =  8 # Mobitex module
+  N_R3964        =  9 # Simatic R3964 module
   N_PROFIBUS_FDL = 10 # Profibus
   N_IRDA         = 11 # Linux IR
-  N_SMSBLOCK     = 12	# SMS block mode
-  N_HDLC         = 13	# synchronous HDLC
-  N_SYNC_PPP     = 14	# synchronous PPP
-  N_HCI          = 15	# Bluetooth HCI UART
+  N_SMSBLOCK     = 12 # SMS block mode
+  N_HDLC         = 13 # synchronous HDLC
+  N_SYNC_PPP     = 14 # synchronous PPP
+  N_HCI          = 15 # Bluetooth HCI UART
 end

--- a/src/bits/ioctls.cr
+++ b/src/bits/ioctls.cr
@@ -2,73 +2,72 @@ require "../asm/ioctls"
 
 module IOCTLS
   # Routing table calls.
-  SIOCADDRT = 0x890B_u32		# add routing table entry
-  SIOCDELRT = 0x890C_u32		# delete routing table entry
-  SIOCRTMSG = 0x890D_u32		# call to routing system
+  SIOCADDRT = 0x890B_u32 # add routing table entry
+  SIOCDELRT = 0x890C_u32 # delete routing table entry
+  SIOCRTMSG = 0x890D_u32 # call to routing system
 
   # Socket configuration controls.
-  SIOCGIFNAME	       = 0x8910_u32	# get iface name
-  SIOCSIFLINK	       = 0x8911_u32	# set iface channel
-  SIOCGIFCONF	       = 0x8912_u32	# get iface list
-  SIOCGIFFLAGS       = 0x8913_u32	# get flags
-  SIOCSIFFLAGS       = 0x8914_u32	# set flags
-  SIOCGIFADDR        = 0x8915_u32	# get PA address
-  SIOCSIFADDR	       = 0x8916_u32	# set PA address
-  SIOCGIFDSTADDR     = 0x8917_u32	# get remote PA address
-  SIOCSIFDSTADDR     = 0x8918_u32	# set remote PA address
-  SIOCGIFBRDADDR     = 0x8919_u32	# get broadcast PA address
-  SIOCSIFBRDADDR     = 0x891a_u32	# set broadcast PA address
-  SIOCGIFNETMASK     = 0x891b_u32	# get network PA mask
-  SIOCSIFNETMASK     = 0x891c_u32	# set network PA mask
-  SIOCGIFMETRIC	     = 0x891d_u32	# get metric
-  SIOCSIFMETRIC	     = 0x891e_u32	# set metric
-  SIOCGIFMEM         = 0x891f_u32	# get memory address (BSD)
-  SIOCSIFMEM         = 0x8920_u32	# set memory address (BSD)
-  SIOCGIFMTU         = 0x8921_u32	# get MTU size
-  SIOCSIFMTU         = 0x8922_u32	# set MTU size
-  SIOCSIFNAME	       = 0x8923_u32	# set interface name
-  SIOCSIFHWADDR      = 0x8924_u32	# set hardware address
-  SIOCGIFENCAP       = 0x8925_u32	# get/set encapsulations
+  SIOCGIFNAME        = 0x8910_u32 # get iface name
+  SIOCSIFLINK        = 0x8911_u32 # set iface channel
+  SIOCGIFCONF        = 0x8912_u32 # get iface list
+  SIOCGIFFLAGS       = 0x8913_u32 # get flags
+  SIOCSIFFLAGS       = 0x8914_u32 # set flags
+  SIOCGIFADDR        = 0x8915_u32 # get PA address
+  SIOCSIFADDR        = 0x8916_u32 # set PA address
+  SIOCGIFDSTADDR     = 0x8917_u32 # get remote PA address
+  SIOCSIFDSTADDR     = 0x8918_u32 # set remote PA address
+  SIOCGIFBRDADDR     = 0x8919_u32 # get broadcast PA address
+  SIOCSIFBRDADDR     = 0x891a_u32 # set broadcast PA address
+  SIOCGIFNETMASK     = 0x891b_u32 # get network PA mask
+  SIOCSIFNETMASK     = 0x891c_u32 # set network PA mask
+  SIOCGIFMETRIC      = 0x891d_u32 # get metric
+  SIOCSIFMETRIC      = 0x891e_u32 # set metric
+  SIOCGIFMEM         = 0x891f_u32 # get memory address (BSD)
+  SIOCSIFMEM         = 0x8920_u32 # set memory address (BSD)
+  SIOCGIFMTU         = 0x8921_u32 # get MTU size
+  SIOCSIFMTU         = 0x8922_u32 # set MTU size
+  SIOCSIFNAME        = 0x8923_u32 # set interface name
+  SIOCSIFHWADDR      = 0x8924_u32 # set hardware address
+  SIOCGIFENCAP       = 0x8925_u32 # get/set encapsulations
   SIOCSIFENCAP       = 0x8926_u32
-  SIOCGIFHWADDR      = 0x8927_u32	# Get hardware address
-  SIOCGIFSLAVE       = 0x8929_u32	# Driver slaving support
+  SIOCGIFHWADDR      = 0x8927_u32 # Get hardware address
+  SIOCGIFSLAVE       = 0x8929_u32 # Driver slaving support
   SIOCSIFSLAVE       = 0x8930_u32
-  SIOCADDMULTI       = 0x8931_u32	# Multicast address lists
+  SIOCADDMULTI       = 0x8931_u32 # Multicast address lists
   SIOCDELMULTI       = 0x8932_u32
-  SIOCGIFINDEX       = 0x8933_u32	# name -> if_index mapping
-  SIOGIFINDEX        = SIOCGIFINDEX	# misprint compatibility :-)
-  SIOCSIFPFLAGS      = 0x8934_u32 # set/get extended flags set
+  SIOCGIFINDEX       = 0x8933_u32   # name -> if_index mapping
+  SIOGIFINDEX        = SIOCGIFINDEX # misprint compatibility :-)
+  SIOCSIFPFLAGS      = 0x8934_u32   # set/get extended flags set
   SIOCGIFPFLAGS      = 0x8935_u32
   SIOCDIFADDR        = 0x8936_u32 # delete PA address
   SIOCSIFHWBROADCAST = 0x8937_u32 # set hardware broadcast addr
   SIOCGIFCOUNT       = 0x8938_u32 # get number of devices
 
-  SIOCGIFBR = 0x8940_u32  # Bridging support
-  SIOCSIFBR = 0x8941_u32  # Set bridging options
+  SIOCGIFBR = 0x8940_u32 # Bridging support
+  SIOCSIFBR = 0x8941_u32 # Set bridging options
 
-  SIOCGIFTXQLEN = 0x8942_u32  # Get the tx queue length
-  SIOCSIFTXQLEN = 0x8943_u32  # Set the tx queue length
-
+  SIOCGIFTXQLEN = 0x8942_u32 # Get the tx queue length
+  SIOCSIFTXQLEN = 0x8943_u32 # Set the tx queue length
 
   # ARP cache control calls.
   #   0x8950 - 0x8952  * obsolete calls, don't re-use
-  SIOCDARP = 0x8953_u32  # delete ARP table entry
-  SIOCGARP = 0x8954_u32  # get ARP table entry
-  SIOCSARP = 0x8955_u32  # set ARP table entry
+  SIOCDARP = 0x8953_u32 # delete ARP table entry
+  SIOCGARP = 0x8954_u32 # get ARP table entry
+  SIOCSARP = 0x8955_u32 # set ARP table entry
 
   # RARP cache control calls.
-  SIOCDRARP	= 0x8960_u32  # delete RARP table entry
-  SIOCGRARP	= 0x8961_u32  # get RARP table entry
-  SIOCSRARP	= 0x8962_u32  # set RARP table entry
+  SIOCDRARP = 0x8960_u32 # delete RARP table entry
+  SIOCGRARP = 0x8961_u32 # get RARP table entry
+  SIOCSRARP = 0x8962_u32 # set RARP table entry
 
   # Driver configuration calls
 
-  SIOCGIFMAP = 0x8970_u32  # Get device parameters
-  SIOCSIFMAP = 0x8971_u32  # Set device parameters
+  SIOCGIFMAP = 0x8970_u32 # Get device parameters
+  SIOCSIFMAP = 0x8971_u32 # Set device parameters
 
   # DLCI configuration calls
-  SIOCADDDLCI	= 0x8980_u32 # Create new DLCI device
-  SIOCDELDLCI	= 0x8981_u32 # Delete DLCI device
+  SIOCADDDLCI = 0x8980_u32 # Create new DLCI device
+  SIOCDELDLCI = 0x8981_u32 # Delete DLCI device
 
   # Device private ioctl calls.
 

--- a/src/ioctl.cr
+++ b/src/ioctl.cr
@@ -10,9 +10,17 @@ module IOCTL
 
   extend self
 
-  def ioctl(fd : LibC::Int, request : UInt32, *arguments)
+  # Executes an `ioctl` call, and returns an `Errno` in case of an error.
+  def ioctl?(fd : LibC::Int, request : UInt32, *arguments) : Errno?
     if LibC.ioctl(fd, request, *arguments) == -1
-      raise Error.new(String.new(LibC.strerror(Errno.value)))
+      return Errno.value
+    end
+  end
+
+  # Executes an `ioctl` call, and raises in case of an error
+  def ioctl(fd : LibC::Int, request : UInt32, *arguments) : Nil
+    if errno = ioctl?(fd, request, *arguments)
+      raise Error.new errno.message
     end
   end
 end


### PR DESCRIPTION
This overhauls the library by changing macros to methods. This improves type safety and documentation, with no real downsides other than being a big breaking-change.

I've also added a non-raising method for `IOCTL.ioctl` , which yields a block. I think it is more idiomatic than returning `String | Nil`, with `String` being an error (!).

Finally, few tests were added, and verified that the results didn't change from the previous macros.